### PR TITLE
Bump version from 3.6.0 to 3.6.1.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,11 +10,11 @@ For OS X there is no website, instead the binaries are hosted together with the 
 
 Two gcc version are provided:
 - avr-gcc 4.9.2 in toolchain 3.5.4 (`atmel-avr-gcc@35` formula), and
-- avr-gcc 5.4.0 in toolchain 3.6.0 (`atmel-avr-gcc` formula).
+- avr-gcc 5.4.0 in toolchain 3.6.1 (`atmel-avr-gcc` formula).
 
 Note that avr-gcc 5.4.0 is the very first GCC for AVRs *from Atmel* to support C++14.
 
 Sidenote:
-At the time of this writing (June 2017), no binaries for toolchain v3.6.0
+At the time of this writing (November 2017), no binaries for toolchain v3.6.1
 *for Linux* exist. The expected, but non-existant URL would be:
-- http://www.atmel.com/images/avr8-gnu-toolchain-3.6.0.1734-linux.any.x86_64.tar.gz
+- http://www.atmel.com/images/avr8-gnu-toolchain-3.6.1.495-linux.any.x86_64.tar.gz

--- a/atmel-avr-gcc.rb
+++ b/atmel-avr-gcc.rb
@@ -3,10 +3,10 @@ require 'formula'
 class AtmelAvrGcc < Formula
 
   homepage 'http://www.atmel.com/tools/ATMELAVRTOOLCHAINFORLINUX.aspx'
-  version '3.6.0'
+  version '3.6.1'
 
-  url 'http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/3.6.0/avr8-gnu-toolchain-osx-3.6.0.487-darwin.any.x86_64.tar.gz'
-  sha256 'e333e1dd9f2a76e6940aa1682a0d740794eacae3ccddebb098e0250e1d2eee7a'
+  url 'http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/3.6.1/avr8-gnu-toolchain-osx-3.6.1.495-darwin.any.x86_64.tar.gz'
+  sha256 'cb6e7658d592ccebe3f51e5954bd089ee146715d972c055895468f8c1b49b41f'
 
   def install
   	(prefix/"avr-gcc").install Dir["./*"]


### PR DESCRIPTION
Atmel does not provide any (signed) checksums so this was calculated
from the downloaded file.